### PR TITLE
目录和js文件同名时解析js文件出错

### DIFF
--- a/lib/parser/js.js
+++ b/lib/parser/js.js
@@ -86,7 +86,7 @@ function getFile(file) {
     return file;
   }
   if (exists(file + '.js') && lstat(file + '.js').isFile()) {
-    return file;
+    return file + '.js';
   }
   // is directory
   if (lstat(file).isDirectory()) {

--- a/lib/parser/js.js
+++ b/lib/parser/js.js
@@ -50,7 +50,7 @@ function transportFile(file, options) {
       if (newfile.charAt(0) !== '.') {
         newfile = './' + newfile;
       }
-      return format('require("%s")', newfile);
+      return format('require("%s")', newfile.replace(/\.js$/, ''));
 
     } else {
       var arr = dep.split('/');

--- a/test/index.js
+++ b/test/index.js
@@ -179,7 +179,7 @@ function wrap(server, middleware) {
     it('should testfile like nodejs', function(done) {
       request(app.listen())
         .get('/testfile/index.js')
-        .expect(util.define('testfile/index.js' , 'require("../index.js");\nrequire(\'./a\');\nrequire("./b/index.js");\nrequire("b/0.1.0/index.js");\nrequire("b/0.1.0/testfile/index.js");\n'))
+        .expect(util.define('testfile/index.js' , 'require("../index");\nrequire(\'./a\');\nrequire("./b/index");\nrequire("b/0.1.0/index.js");\nrequire("b/0.1.0/testfile/index.js");\n'))
         .expect(200, done);
     });
   });


### PR DESCRIPTION
当xxx目录和xxx.js同时存在时，在xxx目录中的js文件require('../xxx')时会变成require('./')，应该是require('../xxx.js')