### PR TITLE
feat(prefix): add options.prefix support

### DIFF
--- a/lib/express.js
+++ b/lib/express.js
@@ -70,7 +70,8 @@ module.exports = function(root, opts) {
     var opt = {
       pkg: pkg,
       ignore: ignore,
-      base: opts.base
+      base: opts.base,
+      prefix: opts.prefix
     };
     debug('return transported file %s', file.path);
     transport(file, opt, function(err, file) {

--- a/lib/koa.js
+++ b/lib/koa.js
@@ -91,7 +91,8 @@ module.exports = function(root, opts) {
       file = yield transportThunk(file, {
         pkg: pkg,
         ignore: ignore,
-        base: opts.base
+        base: opts.base,
+        prefix: opts.prefix
       });
       data = file.contents;
       ext = path.extname(file.path);

--- a/lib/parser/js.js
+++ b/lib/parser/js.js
@@ -22,6 +22,9 @@ function parser(file, options) {
   file.contents = new Buffer(transportFile(file, options));
 
   var id = file.url.pathname.substring(1);
+  if (options.prefix) {
+    id = format('%s/%s', options.prefix, id);
+  }
   // if (options.isEntry) {
   //   id = util.template('{{name}}/{{version}}/{{filepath}}', {
   //     name: pkg.name,
@@ -71,8 +74,9 @@ function transportFile(file, options) {
       }
 
       main = winPath(relative(p.dest, getFile(join(p.dest, main))));
-      return format('require("%s/%s/%s")',
-        p.name, p.version, main);
+      var prefix = options.prefix ? format('%s/', options.prefix) : '';
+      return format('require("%s%s/%s/%s")',
+        prefix, p.name, p.version, main);
     }
   });
 }

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -29,7 +29,7 @@ module.exports = function transport(file, opt, cb) {
     gulpif(/\.coffee$/, coffee({bare: true})),
     gulpif(/\.js$/, pipe(
       reactify(),
-      jsParser({pkg: pkg, ignore: opt.ignore})
+      jsParser({pkg: pkg, ignore: opt.ignore, prefix: opt.prefix})
     )),
     gulpif(/\.tpl$/, tplParser()),
     gulpif(/\.json$/, jsonParser()),

--- a/package.json
+++ b/package.json
@@ -43,13 +43,15 @@
   "devDependencies": {
     "coveralls": "^2.10.0",
     "express": "~4.4.1",
-    "koa": "~0.13.0",
     "istanbul-harmony": "~0.3.0",
+    "koa": "~0.13.0",
+    "koa-mount": "^1.3.0",
     "mocha": "~1.20.0",
+    "pedding": "^1.0.0",
     "request": "~2.36.0",
     "should": "~4.0.0",
     "spy": "^0.1.1",
-    "touch": "0.0.3",
-    "supertest": "~0.14.0"
+    "supertest": "~0.14.0",
+    "touch": "0.0.3"
   }
 }

--- a/test/fixtures/prefix/b/index.js
+++ b/test/fixtures/prefix/b/index.js
@@ -1,0 +1,1 @@
+exports.b = 1;

--- a/test/fixtures/prefix/b/package.json
+++ b/test/fixtures/prefix/b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "simple",
+  "name": "b",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/test/fixtures/prefix/simple/index.js
+++ b/test/fixtures/prefix/simple/index.js
@@ -1,0 +1,1 @@
+exports.a = 1;

--- a/test/fixtures/prefix/simple/package.json
+++ b/test/fixtures/prefix/simple/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "simple",
+  "title": "简单组件",
+  "version": "1.0.0",
+  "description": "",
+  "main": "schema.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "spm": {
+    "main": "index.js"
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -410,6 +410,24 @@ function wrap(server, middleware) {
     });
   });
 
+  describe('prefix', function() {
+
+    before(function() {
+      app = server();
+      app.use(middleware(join(fixtures, 'prefix/simple'), {
+        prefix: 'simple'
+      }));
+    });
+
+    it('with standalone', function(done) {
+      request(app.listen())
+      .get('/index.js')
+      .expect(util.define('simple/index', 'exports.a = 1;\n'))
+      .expect(200, done);
+    });
+
+  });
+
   it('isModified disable', function(done) {
     app = server();
     app.use(middleware(join(fixtures, 'parser')));


### PR DESCRIPTION
增加`options.prefix`支持，可以结合koa-mount，在一个server下支持多个serve-spm的运行。

不过没`prefix`配置支持，那么a组件下有一个index入口文件，b组件也有一个index入口，这样就会冲突了。